### PR TITLE
feat: add siphon test cases to mainnet forking

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,6 @@ jobs:
         run: npx solhint 'contracts/**.sol'
 
       - name: Run unit tests
-        run: npx hardhat test
+        run: yarn test
         env:
           MAINNET_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMY_MAINNET_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Mainnet RSR
+[![Tests](https://github.com/reserve-protocol/rsr-mainnet/actions/workflows/tests.yml/badge.svg)](https://github.com/reserve-protocol/rsr-mainnet/actions/workflows/tests.yml)
+
 This repo contains the code for a mainnet Reserve Rights token (RSR) that upgrades from a previously deployed version of RSR, found [here](https://github.com/reserve-protocol/rsr) and at `0x8762db106b2c2a0bccb3a80d1ed41273552616e8` on Ethereum mainnet.
 
 ## Context

--- a/deployment_plan.md
+++ b/deployment_plan.md
@@ -33,7 +33,7 @@
     * RSR.phase() is 0 (SETUP)
     * RSR.pauser() is CompanySafe
     * RSR.balanceOf(A) = oldRSR.balanceOf(A), for at least one address A with nonzero balances.
-    * Confirm ForkSpell.rsr() is RSR address
+    * Confirm ForkSpell.rsrAddr() is RSR address
 
 ### Phase 2
 **When?**  The earliest convenient time to use OldPauser after Phase 1.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "compile": "TS_NODE_TRANSPILE_ONLY=1 npx hardhat compile",
     "devchain": "npx hardhat node",
     "size": "npx hardhat size-contracts",
-    "test": "npx solhint 'contracts/**.sol' && npx hardhat test",
+    "test": "npx solhint 'contracts/**.sol' && npx hardhat test test/*.test.ts test/integration/*.test.ts",
     "test:coverage": "npx hardhat coverage --testfiles 'test/*.test.ts'",
     "test:mainnet": "npx hardhat test test/integration/*.test.ts",
     "test:local": "npx hardhat test test/*.test.ts",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "repository": "https://github.com/reserve-protocol/rsr-mainnet.git",
   "author": "Reserve Team",
   "license": "BlueOak-1.0.0",
+  "engines": {
+    "node": ">=10.0.0"
+  },
   "scripts": {
     "compile": "TS_NODE_TRANSPILE_ONLY=1 npx hardhat compile",
     "devchain": "npx hardhat node",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "compile": "TS_NODE_TRANSPILE_ONLY=1 npx hardhat compile",
     "devchain": "npx hardhat node",
     "size": "npx hardhat size-contracts",
-    "test": "npx solhint 'contracts/**.sol' && npx hardhat test test/*.test.ts test/integration/*.test.ts",
+    "test": "npx hardhat test test/*.test.ts test/integration/*.test.ts",
     "test:coverage": "npx hardhat coverage --testfiles 'test/*.test.ts'",
     "test:mainnet": "npx hardhat test test/integration/*.test.ts",
     "test:local": "npx hardhat test test/*.test.ts",

--- a/test/integration/RSR-integration.test.ts
+++ b/test/integration/RSR-integration.test.ts
@@ -12,7 +12,7 @@ import { impersonate } from './utils/accounts'
 import { ONE, ZERO, bn } from '../../common/numbers'
 import { WEIGHT_ONE, ZERO_ADDRESS } from '../common'
 
-// TODO: Add more siphon test cases when the contract is deployed
+// Note: More siphon tests cases can be added when the contract is deployed
 // For the mainnet fork, only test the first 5 addresses with balances using different weight values
 const mockWeights = [bn('0'), bn('0.5e18'), WEIGHT_ONE, bn('0.2e18'), bn('0.75e18')]
 const mockSiphons = UPGRADE_SIPHONS.slice(0, 5).map((siphon, index) => ({
@@ -24,8 +24,6 @@ const mockSiphons = UPGRADE_SIPHONS.slice(0, 5).map((siphon, index) => ({
 const RSR_PREVIOUS_ADDRESS = '0x8762db106b2c2a0bccb3a80d1ed41273552616e8'
 const RSR_PAUSER_ADDRESS = '0xBb20467EcccB3F60F8dbEca09a61879893e44069'
 const HOLDER_ADDRESS = '0x72A53cDBBcc1b9efa39c834A540550e23463AAcB'
-// const SLOW_WALLET = '0x4903DC97816f99410E8dfFF51149fA4C3CdaD1b8'
-// const MULTISIG_WALLET = '0xb268c230720D16C69a61CBeE24731E3b2a3330A1'
 
 // Accounts
 let addr1: SignerWithAddress
@@ -40,8 +38,6 @@ let oldRSR: ReserveRightsToken
 let rsr: RSR
 let forkSpell: ForkSpell
 let siphonSpell: SiphonSpell
-// let slowWallet: SlowWallet
-// let multisigWallet: MultiSigWalletWithDailyLimit
 
 // RSR Phases (lifecycle)
 const Phase = {
@@ -74,12 +70,6 @@ const setup = async () => {
   // Impersonate accounts
   pauser = await impersonate(RSR_PAUSER_ADDRESS)
   holder = await impersonate(HOLDER_ADDRESS)
-
-  // TODO: Uncomment when testing the wallets
-  // slowWallet = <SlowWallet>await ethers.getContractAt('SlowWallet', SLOW_WALLET)
-  // multisigWallet = <MultiSigWalletWithDailyLimit>(
-  //   await ethers.getContractAt('MultiSigWalletWithDailyLimit', MULTISIG_WALLET)
-  // )
 }
 
 // Deploy new RSR contract

--- a/test/integration/RSR-integration.test.ts
+++ b/test/integration/RSR-integration.test.ts
@@ -176,7 +176,7 @@ describe('RSR contract - Mainnet Forking', function () {
       })
 
       // *************** Phase 3 *******************
-      describe.only('Then deploying and casting the SiphonSpell (Deployment Phase 3)', async () => {
+      describe('Then deploying and casting the SiphonSpell (Deployment Phase 3)', async () => {
         before(async () => {
           // deploy + cast siphonspell
           await deploySiphon()


### PR DESCRIPTION
## Description of changes
- Add remaining test cases for mainnet fork testing
- Change test order, running mainnet fork first makes the local tests to run under the mainnet fork environment which was the default order.